### PR TITLE
Allow commands with multiple parameters

### DIFF
--- a/lib/extractKeys.js
+++ b/lib/extractKeys.js
@@ -77,7 +77,7 @@ async function extractKeys(adapter, path, element, preferedArrayName, forceIndex
             } else {
                 let type = typeof element[key];
                 if ((path + "." + key).indexOf(".entries.value") !== -1) {
-             
+
                     const entries = await adapter.getObjectAsync(path + "." + key);
                     if (entries) {
                         if (!entries.common.type) {
@@ -89,7 +89,7 @@ async function extractKeys(adapter, path, element, preferedArrayName, forceIndex
                     type = "json";
                 }
                 if (!alreadyCreatedOBjects[path + "." + key]) {
-                  
+
                     await adapter
                         .setObjectNotExistsAsync(path + "." + key, {
                             type: "state",
@@ -120,26 +120,57 @@ async function extractKeys(adapter, path, element, preferedArrayName, forceIndex
                         };
 
                         if (element.params && Object.keys(element.params).length > 0) {
-                            param = Object.keys(element.params)[0];
-                            common.param = param;
-                            if (element.params[param] && element.params[param].type === "number") {
-                                common.type = "number";
-                            }
-                            if (element.params[param] && element.params[param].constraints) {
-                                const constrains = element.params[param].constraints;
-                                if (constrains.min) {
-                                    common.min = constrains.min;
-                                }
-                                if (constrains.max) {
-                                    common.max = constrains.max;
-                                }
-                                if (constrains.enum) {
-                                    common.states = {};
-                                    for (const cenum of constrains.enum) {
-                                        common.states[cenum] = cenum;
-                                    }
-                                }
-                            }
+							if(Object.keys(element.params).length > 1) {
+								common.param = [];
+								common.type = "object";
+								for(let param of Object.keys(element.params)) {
+									let curparam = {
+										param: param,
+										type: "mixed"
+									};
+
+									if (element.params[param] && element.params[param].type === "number") {
+										curparam.type = "number";
+									}
+									if (element.params[param] && element.params[param].constraints) {
+										const constrains = element.params[param].constraints;
+										if (constrains.min) {
+											curparam.min = constrains.min;
+										}
+										if (constrains.max) {
+											curparam.max = constrains.max;
+										}
+										if (constrains.enum) {
+											curparam.states = {};
+											for (const cenum of constrains.enum) {
+												curparam.states[cenum] = cenum;
+											}
+										}
+									}
+									common.param.push(curparam);
+								}
+							} else {
+								param = Object.keys(element.params)[0];
+								common.param = param;
+								if (element.params[param] && element.params[param].type === "number") {
+									common.type = "number";
+								}
+								if (element.params[param] && element.params[param].constraints) {
+									const constrains = element.params[param].constraints;
+									if (constrains.min) {
+										common.min = constrains.min;
+									}
+									if (constrains.max) {
+										common.max = constrains.max;
+									}
+									if (constrains.enum) {
+										common.states = {};
+										for (const cenum of constrains.enum) {
+											common.states[cenum] = cenum;
+										}
+									}
+								}
+							}
                         }
                         await adapter.setObjectNotExistsAsync(setStatePath, {
                             type: "state",

--- a/main.js
+++ b/main.js
@@ -478,19 +478,35 @@ class Viessmannapi extends utils.Adapter {
                 const uriState = await this.getStateAsync(parentPath + ".uri");
                 const idState = await this.getObjectAsync(parentPath + ".setValue");
 
+                const data = {};
+
                 const param = idState.common.param;
+				if (param) {
+					if (typeof param !== 'object' || !Array.isArray(param)) {
+						data[param] = state.val;
+						if (!isNaN(state.val)) {
+							data[param] = Number(state.val);
+						}
+					} else {
+						let stateval = JSON.parse(state.val);
+						for (let entry of param) {
+							if (typeof stateval[entry.param] !== 'undefined') {
+								data[entry.param] = stateval[entry.param];
+								if (!isNaN(data[entry.param])) {
+									data[entry.param] = Number(data[entry.param]);
+								}
+							}
+						}
+					}
+				}
 
                 if (!uriState || !uriState.val) {
                     this.log.info("No URI found");
                     return;
                 }
-                const data = {};
-                if (param) {
-                    data[param] = state.val;
-                    if (!isNaN(state.val)) {
-                        data[param] = Number(state.val);
-                    }
-                }
+
+				this.log.debug('Data to send: ' + JSON.stringify(data));
+				
                 const headers = {
                     "Content-Type": "application/json",
                     Accept: "*/*",


### PR DESCRIPTION
Might fix #18 

The setValue objects need to be removed manually before adapter restart so they will be recreated with correct data. Should be improved to update object data automatically.

Setting works e. g. by using `{"slope": 0.3, "shift": 1}` for `viessmannapi.0.xxxxx.0.features.heating.circuits.0.heating.curve.commands.setCurve.setValue`