### PR TITLE
Update main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -269,7 +269,7 @@ class Viessmannapi extends utils.Adapter {
     const statusArray = [
       {
         path: 'features',
-        url: 'https://api.viessmann.com/iot/v1/features/installations/$installation/gateways/$gatewaySerial/devices/$id/features',
+        url: 'https://api.viessmann.com/iot/v2/features/installations/$installation/gateways/$gatewaySerial/devices/$id/features',
         desc: 'Features and States of the device',
       },
     ];


### PR DESCRIPTION
Switch to v2 of IoT Features API, as v1 will be deprecated End of month. Change is described in the API Documentation: https://documentation.viessmann.com/static/changelog